### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Quickstart
 
 3. Run the Dashboard
 
-	`docker run -d --name tyk_dashboard -p 3000:3000 --link tyk_redis:redis --link tyk_mongo:mongo--link tyk_gateway:tyk_gateway tykio/tyk-dashboard`
+	`docker run -d --name tyk_dashboard -p 3000:3000 --link tyk_redis:redis --link tyk_mongo:mongo --link tyk_gateway:tyk_gateway tykio/tyk-dashboard`
 
 4. You should now be able to access your Dashboard at `http://dashboard.tyk.docker:3000/` (note for OSX users, replace 127.0.0.1 with whatever IP address your docker VM runs)
 


### PR DESCRIPTION
This PR is about https://github.com/TykTechnologies/tyk-dashboard-docker/blob/master/README.md .

This PR adds missing space between `tyk_mongo:mongo` and `--link`.