### PR TITLE
Feature/admin auth security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:jessie-slim
 
-ENV TYKVERSION 1.8.0
+ENV TYKVERSION 1.8.1
 ENV TYKLISTENPORT 3000
 
 LABEL Description="Tyk Dashboard docker image" Vendor="Tyk" Version=$TYKVERSION
@@ -26,6 +26,7 @@ RUN echo "deb https://packagecloud.io/tyk/tyk-dashboard/debian/ jessie main" | t
 
 
 COPY ./tyk_analytics.with_mongo_and_gateway.conf /opt/tyk-dashboard/tyk_analytics.conf
+RUN RANDOM_ADMIN_PASSWORD=$(env LC_CTYPE=C tr -dc "a-z0-9" < /dev/urandom | head -c 32) && sed -i "s/ADMIN_SECRET_PLACEHOLDER/$RANDOM_ADMIN_PASSWORD/g" /opt/tyk-dashboard/tyk_analytics.conf
 VOLUME ["/opt/tyk-dashboard"]
 WORKDIR /opt/tyk-dashboard
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -3,16 +3,17 @@
 
 LOCALIP=$1
 RANDOM_USER=$(env LC_CTYPE=C tr -dc "a-z0-9" < /dev/urandom | head -c 10)
+ADMIN_PASS=$(docker run -it --entrypoint bash tyk-dashboard -c 'cat tyk_analytics.conf | grep admin_secret | cut -d"\"" -f4')
 PASS="test123"
 
 echo "Creating Organisation"
-ORGDATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" --data '{"owner_name": "Default Org.","owner_slug": "default", "cname_enabled": true, "cname": ""}' http://$LOCALIP:3000/admin/organisations 2>&1)
+ORGDATA=$(curl --silent --header "admin-auth: $ADMIN_PASS" --header "Content-Type:application/json" --data '{"owner_name": "Default Org.","owner_slug": "default", "cname_enabled": true, "cname": ""}' http://$LOCALIP:3000/admin/organisations 2>&1)
 #echo $ORGDATA
 ORGID=$(echo $ORGDATA | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["Meta"])')
 echo "ORGID: $ORGID" 
 
 echo "Adding new user"
-USER_DATA=$(curl --silent --header "admin-auth: 12345" --header "Content-Type:application/json" --data '{"first_name": "John","last_name": "Smith","email_address": "'$RANDOM_USER'@example.com","password":"'$PASS'", "active": true,"org_id": "'$ORGID'"}' http://$LOCALIP:3000/admin/users 2>&1)
+USER_DATA=$(curl --silent --header "admin-auth: $ADMIN_PASS" --header "Content-Type:application/json" --data '{"first_name": "John","last_name": "Smith","email_address": "'$RANDOM_USER'@example.com","password":"'$PASS'", "active": true,"org_id": "'$ORGID'"}' http://$LOCALIP:3000/admin/users 2>&1)
 #echo $USER_DATA
 USER_CODE=$(echo $USER_DATA | python -c 'import json,sys;obj=json.load(sys.stdin);print(obj["Message"])')
 echo "USER AUTH: $USER_CODE" 

--- a/tyk_analytics.with_mongo_and_gateway.conf
+++ b/tyk_analytics.with_mongo_and_gateway.conf
@@ -9,7 +9,7 @@
     "mongo_url": "mongodb://mongo:27017/tyk_analytics",
     "license_key": "",
     "page_size": 10,
-    "admin_secret": "12345",
+    "admin_secret": "ADMIN_SECRET_PLACEHOLDER",
     "redis_port": 6379,
     "redis_host": "redis",
     "redis_password": "",


### PR DESCRIPTION
The intention of this PR is to improve the overall security of the Tyk Dashboard, by avoiding the usage of a default password (as 12345) and using a randomly generated password instead. The downside of this approach - which may be also improved in the future - is that the `bootstrap.sh` script must be run on the host machine of the docker container.