### PR TITLE
WIP: adds script to load legacy env variables into new ones for backwards compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,11 +26,13 @@ RUN echo "deb https://packagecloud.io/tyk/tyk-dashboard/debian/ jessie main" | t
 
 
 COPY ./tyk_analytics.with_mongo_and_gateway.conf /opt/tyk-dashboard/tyk_analytics.conf
+COPY ./entrypoint.sh /opt/tyk-dashboard/entrypoint.sh
 VOLUME ["/opt/tyk-dashboard"]
 WORKDIR /opt/tyk-dashboard
 
 EXPOSE $TYKLISTENPORT
 EXPOSE 5000
 
-ENTRYPOINT ["/opt/tyk-dashboard/tyk-analytics", "--conf=/opt/tyk-dashboard/tyk_analytics.conf"]
+
+ENTRYPOINT ["./entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+TYKDBCONF=/opt/tyk-dashboard/tyk_analytics.conf
+
+# for backwards compatibility, set legacy variables to new ones
+if [[ -n "${TYK_DB_HOSTCONFIG_GATEWAYHOSTNAME}" ]]; then
+  export TYK_DB_HOSTCONFIG_OVERRIDEHOSTNAME="${TYK_DB_HOSTCONFIG_GATEWAYHOSTNAME}"
+fi
+
+if [[ -n "${TYK_DB_HOSTCONFIG_GENERATEHTTPS}" ]]; then
+  export TYK_DB_HOSTCONFIG_GENERATESECUREPATHS="${TYK_DB_HOSTCONFIG_GENERATEHTTPS}"
+fi
+
+if [[ -n "${TYK_DB_HOSTCONFIG_USESTRICT}" ]]; then
+  export TYK_DB_HOSTCONFIG_USESTRICTHOSTMATCH="${TYK_DB_HOSTCONFIG_USESTRICT}"
+fi
+
+if [[ -n "${TYK_DB_HOSTCONFIG_TYKAPI_HOST}" ]]; then
+  export TYK_DB_HOSTCONFIG_TYKAPICONFIG_HOST="${TYK_DB_HOSTCONFIG_TYKAPI_HOST}"
+fi
+
+if [[ -n "${TYK_DB_HOSTCONFIG_TYKAPI_PORT}" ]]; then
+  export TYK_DB_HOSTCONFIG_TYKAPICONFIG_PORT="${TYK_DB_HOSTCONFIG_TYKAPI_PORT}"
+fi
+
+if [[ -n "${TYK_DB_HOSTCONFIG_TYKAPI_SECRET}" ]]; then
+  export TYK_DB_HOSTCONFIG_TYKAPICONFIG_SECRET="${TYK_DB_HOSTCONFIG_TYKAPI_SECRET}"
+fi
+
+if [[ -n "${TYK_DB_NODESECRET}" ]]; then
+  export TYK_DB_SHAREDNODESECRET="${TYK_DB_NODESECRET}"
+fi
+
+# todo:
+# TIB <-> IdentityBroker
+# HttpServerOptions-SSLCiphers
+# HttpServerOptions-PreferServerCiphers
+# Hosts <-> RedisHosts
+
+
+cd /opt/tyk-dashboard/
+./tyk-analytics --conf=${TYKDBCONF}


### PR DESCRIPTION
this is a Docker script that works with this:
https://github.com/TykTechnologies/tyk-analytics/pull/1635

this would need to be merged first

edit: need to figure out what to do with `Hosts` <-> `RedisHosts` .  It is just a map which means if anyone is using this they will need to be notified to change this env variable,  I can't think of a way to make this backwards compatible without some Unix wizardry