### PR TITLE
Deprecate API Blueprint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ RUN apt-get update \
  && apt-get upgrade -y \
  && apt-get install -y --no-install-recommends \
             curl ca-certificates apt-transport-https gnupg \
-            build-essential \
  && curl -L https://packagecloud.io/tyk/tyk-dashboard/gpgkey | apt-key add - \
- && apt-get purge -y build-essential gnupg \
+ && apt-get purge -y gnupg \
  && apt-get autoremove -y \
  && rm -rf /root/.cache
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,13 +11,9 @@ RUN apt-get update \
             curl ca-certificates apt-transport-https gnupg \
             build-essential \
  && curl -L https://packagecloud.io/tyk/tyk-dashboard/gpgkey | apt-key add - \
- && curl -sL https://deb.nodesource.com/setup_8.x | bash - \
- && apt-get install -y --no-install-recommends --allow-downgrades nodejs=8.17.0-1nodesource1 python-dev \
- && npm config set user 0 && npm config set unsafe-perm true \
- && npm install -g aglio \
- && apt-get purge -y build-essential gnupg python-dev \
+ && apt-get purge -y build-essential gnupg \
  && apt-get autoremove -y \
- && rm -rf /root/.npm && rm -rf /root/.node-gyp
+ && rm -rf /root/.cache
 
 RUN echo "deb https://packagecloud.io/tyk/tyk-dashboard/debian/ jessie main" | tee /etc/apt/sources.list.d/tyk_tyk-dashboard.list \
  && apt-get update \


### PR DESCRIPTION
Deprecate API Blueprint from Tyk Dashboard docker images. Here is the community announcements: https://community.tyk.io/t/deprecating-api-blueprint/3839

To be released into Tyk 3.1 version.
